### PR TITLE
Update Infector runtime to 46

### DIFF
--- a/uk.co.mangobrain.Infector.json
+++ b/uk.co.mangobrain.Infector.json
@@ -1,7 +1,7 @@
 {
   "app-id": "uk.co.mangobrain.Infector",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "44",
+  "runtime-version": "46",
   "sdk": "org.gnome.Sdk",
   "command": "infector",
   "rename-icon": "infector",

--- a/uk.co.mangobrain.Infector.metainfo.xml
+++ b/uk.co.mangobrain.Infector.metainfo.xml
@@ -13,7 +13,13 @@
       players, locally or over a network.
     </p>
   </description>
-  <url type="homepage">http://infector.mangobrain.co.uk/</url>
+  <url type="homepage">https://github.com/mangobrain/Infector</url>
+  <url type="bugtracker">https://github.com/mangobrain/Infector/issues</url>
+  <url type="vcs-browser">https://github.com/mangobrain/Infector</url>
+  <developer_name>Philip Allison</developer_name>
+  <developer id="uk.co.mangobrain">
+    <name>Philip Allison</name>
+  </developer>
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/flathub/uk.co.mangobrain.Infector/master/screenshots/screenshot1.png</image>
@@ -28,7 +34,7 @@
       <image>https://raw.githubusercontent.com/flathub/uk.co.mangobrain.Infector/master/screenshots/screenshot4.png</image>
     </screenshot>
   </screenshots>
-  <content_rating type="oars-1.0" />
+  <content_rating type="oars-1.1" />
   <releases>
     <release version="0.7" date="2018-03-24" />
   </releases>


### PR DESCRIPTION
- Update Infector runtime to 46 since runtime version 44 has reached end-of-life.
- Update appdata information to Appstream 1.0 specs.

More information: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/