### PR TITLE
Remove mm-common

### DIFF
--- a/uk.co.mangobrain.Infector.json
+++ b/uk.co.mangobrain.Infector.json
@@ -31,21 +31,6 @@
   ],
   "modules": [
     {
-      "name": "mm-common",
-      "buildsystem": "meson",
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.5.tar.xz",
-          "sha256": "705c6d29f4116a29bde4e36cfc1b046c92b6ef8c6dae4eaec85018747e6da5aa"
-        }
-      ],
-      "cleanup": [
-        "/share/mm-common",
-        "/bin/mm-common*"
-      ]
-    },
-    {
       "name": "sigc++",
       "buildsystem": "meson",
       "config-opts": [


### PR DESCRIPTION
When building libxml++, libsigc++ and glibmm from current release tarballs, mm-common is no longer needed. See:
- libxml++ [NEWS](https://github.com/libxmlplusplus/libxmlplusplus/blob/e37ba77403cbbdccf1975043bd05df881c4ed024/NEWS#L187):
> Do not require mm-common during the tarball build.

- libsig++ [NEWS](https://github.com/libsigcplusplus/libsigcplusplus/blob/5cdc3cfba613ced119e2853bce85a070dbcca46a/NEWS#L712):
> New build system based on mm-common. The mm-common module is now
> required for building from the git repository, but not for builds
> of release archives.

- glibmm [NEWS](https://github.com/GNOME/glibmm/blob/efa83dfd2e1fb413eb8da9af870f1ffd8a632399/NEWS#L3741):
> Remove the dependency on mm-common during the tarball build.

Thanks to @yakushabb for bringing this to my attention in https://github.com/flathub/org.kde.kmymoney/pull/78

Source: https://github.com/flathub/org.kde.kmymoney/pull/80